### PR TITLE
Add first NPC sprite image canvas

### DIFF
--- a/app.js
+++ b/app.js
@@ -121,6 +121,22 @@ function drawCanvas() {
     ctx.drawImage(genColourSprite(spriteSheet, 0, 0 + (curSel["hair"] * 32), 32, 32, PALETTE[curColor["hair"]], 5), 0, 0);
 }
 
+/* 64 x 36 Bust Sprite */
+function drawBustSprite() {
+    var bustCanvas = document.getElementById("npcBust");
+    var canvas = document.getElementById("npcBustSpr");
+    var ctx = canvas.getContext("2d");
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(bustCanvas, 0, 0);
+    ctx.drawImage(bustCanvas, 32, 0);
+}
+
+
+
 spriteSheet.onload = function() {
     drawCanvas();
+    drawBustSprite();
 }
+
+

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <div class="card-title"> APICO NPC Generator</div>
         <div class="card-content">
             <div class="card-photo">
-                <canvas id="npcBust" width="32" height="36" style="border:1px solid #000000;"> </canvas>
+                <canvas class="main-canvas" id="npcBust" width="32" height="36" style="border:1px solid #000000;"> </canvas>
             </div>
             <div class="selectors">
                 <div class="pair">
@@ -35,6 +35,9 @@
                     </div>
                 </div>
             </div>
+        </div>
+        <div> 
+            <p> Sprite Images </p>
         </div>
         <div class="card-content">
             <canvas id="npcBustSpr" width="64" height="36"></canvas>

--- a/main.css
+++ b/main.css
@@ -40,7 +40,7 @@
     border: 2px solid white;
 }
 
-canvas {
+.main-canvas {
     width: 256px;
     height: 288px;
     image-rendering: -moz-crisp-edges;
@@ -88,6 +88,7 @@ canvas {
     justify-content: space-between;
     box-shadow: 0px 2px 14px;
     padding: 5px;
+    border-radius: 8px;
 }
 
 .selectors {


### PR DESCRIPTION
Brings in the first sprite image canvas.
NPC Bust. At the moment these aren't zipped and have to be right-clicked to download them.